### PR TITLE
Fixed 5G enable for R8000

### DIFF
--- a/netgear.js
+++ b/netgear.js
@@ -21,7 +21,7 @@ const actionSetBlockDevice = 'urn:NETGEAR-ROUTER:service:DeviceConfig:1#SetBlock
 const actionSetGuestAccessEnabled = 'urn:NETGEAR-ROUTER:service:WLANConfiguration:1#SetGuestAccessEnabled';
 const actionSetGuestAccessEnabled2 = 'urn:NETGEAR-ROUTER:service:WLANConfiguration:1#SetGuestAccessEnabled2';
 const actionSet5GGuestAccessEnabled = 'urn:NETGEAR-ROUTER:service:WLANConfiguration:1#Set5GGuestAccessEnabled';
-const actionSet5GGuestAccessEnabled2 = 'urn:NETGEAR-ROUTER:service:WLANConfiguration:1#Set5GGuestAccessEnabled2';
+const actionSet5GGuestAccessEnabled2 = 'urn:NETGEAR-ROUTER:service:WLANConfiguration:1#Set5G1GuestAccessEnabled2';
 const actionReboot = 'urn:NETGEAR-ROUTER:service:DeviceConfig:1#Reboot';
 
 const defaultSessionId = 'A7D88AE69687E58D9A00';	// '10588AE69687E58D9A00'
@@ -156,15 +156,6 @@ function soapSet5GGuestAccessEnabled(sessionId, enabled) {
 		<M1:Set5GGuestAccessEnabled xmlns:M1="urn:NETGEAR-ROUTER:service:WLANConfiguration:1">
 			<NewGuestAccessEnabled>${enabled*1}</NewGuestAccessEnabled>
 		</M1:Set5GGuestAccessEnabled>
-	</SOAP-ENV:Body>`;
-	return soapEnvelope(sessionId, soapBody);
-}
-
-function soapSet5GGuestAccessEnabled2(sessionId, enabled) {
-	const soapBody = `<SOAP-ENV:Body>
-		<M1:Set5GGuestAccessEnabled2 xmlns:M1="urn:NETGEAR-ROUTER:service:WLANConfiguration:1">
-			<NewGuestAccessEnabled>${enabled*1}</NewGuestAccessEnabled>
-		</M1:Set5GGuestAccessEnabled2>
 	</SOAP-ENV:Body>`;
 	return soapEnvelope(sessionId, soapBody);
 }
@@ -572,7 +563,7 @@ class NetgearRouter {
 				.catch((err) => {
 					reject(Error(`set5GGuestAccessEnabled2 request failed. (config started failure: ${err})`));
 				});
-			const message = soapSet5GGuestAccessEnabled2(this.sessionId, enabled);
+			const message = soapSet5GGuestAccessEnabled(this.sessionId, enabled);
 			await this._makeRequest(actionSet5GGuestAccessEnabled2, message)
 				.catch((error) => {
 					reject(error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netgear",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Node module to interact with Netgear routers via SOAP",
   "main": "netgear.js",
   "scripts": {


### PR DESCRIPTION
Hi Robin,

I retested your update `v.1.5.0` and it does not function on my R8000. (Firmware: `V1.0.4.18_10.1.49` which I believe is the latest).

While it does seems strange - this PR uses values that function correctly. Somewhat strangely, the `Set5G1GuestAccessEnabled2` action value actually corresponds to the first 5G Guest network in the web admin, while the `Set5GGuestAccessEnabled` seems to be the second (at least for me). 

Maybe there is someone else with an R8000 who can confirm?